### PR TITLE
Intent - Extension methods in order to chain the calls 

### DIFF
--- a/kandroid/src/main/java/com/pawegio/kandroid/KIntent.kt
+++ b/kandroid/src/main/java/com/pawegio/kandroid/KIntent.kt
@@ -16,12 +16,20 @@
 
 package com.pawegio.kandroid
 
+import android.app.Activity
+import android.app.Fragment
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Patterns
 
 inline fun <reified T : Any> IntentFor(context: Context): Intent = Intent(context, T::class.java)
+
+inline fun Intent.start(ctx: Context) = ctx.startActivity(this)
+
+inline fun Intent.startForResult(a: Activity, requestCode: Int) = a.startActivityForResult(this, requestCode)
+
+inline fun Intent.startForResult(f: Fragment, requestCode: Int) = f.startActivityForResult(this, requestCode)
 
 inline fun WebIntent(url: String): Intent {
     return if (Patterns.WEB_URL.matcher(url).matches()) {


### PR DESCRIPTION
I think, would be nice if we can do something like :

``` kotlin
IntentFor<MyActivity>(context).start(context)
```

``` kotlin
IntentFor<MyActivity>(context)
   .putExtra("name", value)
   .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
   .start(context)
```

or

``` kotlin
IntentFor<MyActivity>(context)
   .putExtra("phone", phone)
   .startForResult(activity, MyReqCode )
```
