### PR TITLE
find() fix and deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-25.0.3
-    - android-25
+    - build-tools-26.0.1
+    - android-26
     - extra-android-m2repository
 
 before_script:

--- a/kandroid/src/main/kotlin/com/pawegio/kandroid/KActivity.kt
+++ b/kandroid/src/main/kotlin/com/pawegio/kandroid/KActivity.kt
@@ -27,7 +27,8 @@ import android.support.annotation.StringRes
 import android.view.View
 import android.widget.Toast
 
-inline fun <reified T : View> Activity.find(@IdRes id: Int): T = findViewById(id) as T
+@Deprecated("Use findViewById() instead", ReplaceWith("findViewById()"))
+inline fun <reified T : View> Activity.find(@IdRes id: Int): T = findViewById(id)
 
 inline fun Activity.toast(text: CharSequence): Unit = Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
 

--- a/kandroid/src/main/kotlin/com/pawegio/kandroid/KActivity.kt
+++ b/kandroid/src/main/kotlin/com/pawegio/kandroid/KActivity.kt
@@ -28,7 +28,7 @@ import android.view.View
 import android.widget.Toast
 
 @Deprecated("Use findViewById() instead", ReplaceWith("findViewById()"))
-inline fun <reified T : View> Activity.find(@IdRes id: Int): T = findViewById(id) as T
+inline fun <reified T : View> Activity.find(@IdRes id: Int): T = findViewById(id)
 
 inline fun Activity.toast(text: CharSequence): Unit = Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
 

--- a/kandroid/src/main/kotlin/com/pawegio/kandroid/KActivity.kt
+++ b/kandroid/src/main/kotlin/com/pawegio/kandroid/KActivity.kt
@@ -28,7 +28,7 @@ import android.view.View
 import android.widget.Toast
 
 @Deprecated("Use findViewById() instead", ReplaceWith("findViewById()"))
-inline fun <reified T : View> Activity.find(@IdRes id: Int): T = findViewById(id)
+inline fun <reified T : View> Activity.find(@IdRes id: Int): T = findViewById(id) as T
 
 inline fun Activity.toast(text: CharSequence): Unit = Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
 

--- a/kandroid/src/main/kotlin/com/pawegio/kandroid/KView.kt
+++ b/kandroid/src/main/kotlin/com/pawegio/kandroid/KView.kt
@@ -22,7 +22,8 @@ import android.support.annotation.IdRes
 import android.view.View
 import android.view.View.*
 
-inline fun <reified T : View> View.find(@IdRes id: Int): T = findViewById(id) as T
+@Deprecated("Use findViewById() instead", ReplaceWith("findViewById()"))
+inline fun <reified T : View> View.find(@IdRes id: Int): T = findViewById(id)
 
 var View.visible
     get() = visibility == VISIBLE

--- a/kandroid/src/main/kotlin/com/pawegio/kandroid/KView.kt
+++ b/kandroid/src/main/kotlin/com/pawegio/kandroid/KView.kt
@@ -23,7 +23,7 @@ import android.view.View
 import android.view.View.*
 
 @Deprecated("Use findViewById() instead", ReplaceWith("findViewById()"))
-inline fun <reified T : View> View.find(@IdRes id: Int): T = findViewById(id)
+inline fun <reified T : View> View.find(@IdRes id: Int): T = findViewById(id) as T
 
 var View.visible
     get() = visibility == VISIBLE

--- a/kandroid/src/main/kotlin/com/pawegio/kandroid/KView.kt
+++ b/kandroid/src/main/kotlin/com/pawegio/kandroid/KView.kt
@@ -23,7 +23,7 @@ import android.view.View
 import android.view.View.*
 
 @Deprecated("Use findViewById() instead", ReplaceWith("findViewById()"))
-inline fun <reified T : View> View.find(@IdRes id: Int): T = findViewById(id) as T
+inline fun <reified T : View> View.find(@IdRes id: Int): T = findViewById(id)
 
 var View.visible
     get() = visibility == VISIBLE


### PR DESCRIPTION
No needed anymore, because standard library method **findViewById()** now contains generic.

![find](https://user-images.githubusercontent.com/1530314/29214118-bb365b7e-7eae-11e7-8c1d-cc622f009979.png)
