### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Download
 --------
 
 Download latest version with Gradle:
+Groovy:
 ```groovy
 allprojects { 
     repositories {
@@ -16,6 +17,27 @@ allprojects {
     }
 }
 
+dependencies {
+    implementation 'com.github.pawegio:KAndroid:0.8.7@aar'
+}
+```
+Kotlin:
+1. In `settings.gradle.kts` file:
+```kotlin
+pluginManagement {
+    repositories {
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+2. In `build.gradle.kts` file
+```
 dependencies {
     implementation 'com.github.pawegio:KAndroid:0.8.7@aar'
 }


### PR DESCRIPTION
Update dependency configuration for JitPack in Kotlin DSL

Previously, JitPack repository was configured using Groovy syntax in the `build.gradle` file.

Updated configuration:
- Added JitPack repository setup in `settings.gradle.kts` for plugin management and dependency resolution.
- Confirmed `KAndroid` dependency declaration in `build.gradle.kts` using Kotlin DSL.

This change ensures proper integration of JitPack in Kotlin DSL.